### PR TITLE
feat: support timezone

### DIFF
--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -214,10 +214,12 @@ interface class ChatService {
       final Uri connectionUrl;
 
       final channelName = currentChannel;
+      final timezoneOffset = DateTime.now().timeZoneOffset.inHours;
       connectionUrl = websocketUrl.replace(
         queryParameters: {
           ...websocketUrl.queryParameters,
           'channel': channelName,
+          'tz': '$timezoneOffset',
         },
       );
 


### PR DESCRIPTION
`lisp-chat` now supports timezone: https://github.com/ryukinix/lisp-chat/pull/149

This PR implements timezone in Lispinto Chat.